### PR TITLE
fix getting value from non existing key from redis

### DIFF
--- a/src/Store/PredisStore.php
+++ b/src/Store/PredisStore.php
@@ -27,7 +27,7 @@ class PredisStore implements ValueStoreInterface, LockStoreInterface
             $value = unserialize($value);
         }
 
-        return $value;
+        return $value === null ? false : $value;
     }
 
     public function delete($key)

--- a/tests/src/Store/AbstractStoreTest.php
+++ b/tests/src/Store/AbstractStoreTest.php
@@ -47,6 +47,11 @@ abstract class AbstractStoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->store->get($key));
     }
 
+    public function testGettingNotSetValue()
+    {
+        $this->assertFalse($this->store->get(microtime()));
+    }
+
     public function keyValuePairsProvider()
     {
         return [


### PR DESCRIPTION
Metaphore relies on 'false' type to mark result value as non existing

Redis will return NULL when key does not exist
http://redis.io/commands/GET

That's why there is a need to cast `null` to `false` when getting value from redis